### PR TITLE
Fixes Issue 18

### DIFF
--- a/remoteapp-tool/My Project/AssemblyInfo.vb
+++ b/remoteapp-tool/My Project/AssemblyInfo.vb
@@ -18,7 +18,7 @@ Imports System.Runtime.InteropServices
 <Assembly: ComVisible(False)>
 
 'The following GUID is for the ID of the typelib if this project is exposed to COM
-<Assembly: Guid("fbd55db5-06ea-4e43-92a4-6e96893013cc")> 
+<Assembly: Guid("fbd55db5-06ea-4e43-92a4-6e96893013cc")>
 
 ' Version information for an assembly consists of the following four values:
 '
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("5.4.0.0")> 
-<Assembly: AssemblyFileVersion("5.4.0.0")> 
+<Assembly: AssemblyVersion("5.4.0.18")>
+<Assembly: AssemblyFileVersion("5.4.0.18")>

--- a/remoteapp-tool/RemoteAppCreateClientConnection.vb
+++ b/remoteapp-tool/RemoteAppCreateClientConnection.vb
@@ -224,10 +224,13 @@ Public Class RemoteAppCreateClientConnection
                 If ExtractToIco(RemoteApp.IconPath, RemoteApp.IconIndex, IconFilePath) = False Then
                     MessageBox.Show("Icon could not be created the RemoteApp. RDP file will still be created.", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Exclamation)
                 End If
-                For Each FTA As RemoteAppLib.FileTypeAssociation In RemoteApp.FileTypeAssociations
-                    Dim ProductFileName = VB.Left(RDPPath, RDPPath.Length - 4)
-                    ExtractFTIcon(ProductFileName, FTA)
-                Next
+                ' Check if there are file type associations before trying to work with the file type association icons
+                If Not (RemoteApp.FileTypeAssociations Is Nothing) Then
+                    For Each FTA As RemoteAppLib.FileTypeAssociation In RemoteApp.FileTypeAssociations
+                        Dim ProductFileName = VB.Left(RDPPath, RDPPath.Length - 4)
+                        ExtractFTIcon(ProductFileName, FTA)
+                    Next
+                End If
             End If
             Me.Close()
         Else


### PR DESCRIPTION
Fixes issue 18
  *  Issue 18 was caused by the file type association icon extraction.  If no file type associations were set up, the object was not defined which resulted in an error
  *  Fix was to check if the object exists prior to looking at values in it